### PR TITLE
Commands should assume that all other commands are on the path.

### DIFF
--- a/bin/bt-go
+++ b/bin/bt-go
@@ -23,7 +23,7 @@ Grit.debug = true if opts[:debug]
 
 r = BT::Repository.new opts[:directory]
 
-while (stage = r.commit(opts[:commit]).pipeline.ready.first)
+while (stage = r.commit(opts[:commit]).stages.select(&:ready?).first)
   stage.build
   puts "#{stage.name}: #{stage.result}"
   break if opts[:once]

--- a/bin/bt-ready
+++ b/bin/bt-ready
@@ -7,5 +7,5 @@ require 'bt'
 include BT::Cli
 
 single_repo_cmd('ready', 'List stages ready to go') do |r|
-  r.head.pipeline.ready.each { |s| puts s.name }
+  r.head.stages.select(&:ready?).each { |s| puts s.name }
 end

--- a/bin/bt-results
+++ b/bin/bt-results
@@ -21,7 +21,7 @@ Grit.debug = true if opts[:debug]
 BT::Repository.mirror(opts[:uri]) do |r|
   r.update
   commit = r.commit(opts[:commit])
-  stages = commit.pipeline.stages.sort {|a, b| b.needs.count <=> a.needs.count }
+  stages = commit.stages.sort {|a, b| b.needs.count <=> a.needs.count }
 
   puts "Results (#{commit.sha}):\n\n"
 

--- a/bin/bt-watch
+++ b/bin/bt-watch
@@ -22,7 +22,7 @@ uri = ARGV.shift || Dir.pwd
 
 class Agent < Struct.new :io
   def self.start stage
-    build = "#{stage.pipeline.commit.sha}/#{stage.name}"
+    build = "#{stage.commit.sha}/#{stage.name}"
 
     IO.popen("#{find_command :agent} #{build}") do |io|
       yield new io
@@ -42,7 +42,7 @@ end
 BT::Repository.mirror(uri) do |r|
   while true
     r.update
-    if stage = r.head.pipeline.ready.shuffle.first
+    if stage = r.head.stages.select(&:ready?).shuffle.first
       Agent.start stage do |a|
         if a.leading?
           stage.build

--- a/env
+++ b/env
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+PATH=$PATH:"$(pwd)/bin"
+
+exec $@

--- a/lib/bt.rb
+++ b/lib/bt.rb
@@ -1,6 +1,6 @@
 require 'bt/cli'
 require 'bt/git'
-require 'bt/pipeline'
+require 'bt/stage'
 
 module BT
   VERSION = '0.0.1'

--- a/lib/bt/cli.rb
+++ b/lib/bt/cli.rb
@@ -18,25 +18,8 @@ Usage:
       yield Repository.new ARGV.shift || Dir.pwd
     end
 
-    def bin_path
-      begin
-        Gem.bin_path BT::NAME
-      rescue Gem::GemNotFoundException
-        begin
-          require 'bundler'
-          begin
-            Bundler.bin_path
-          rescue Bundler::GemfileNotFound
-            raise LoadError
-          end
-        rescue LoadError
-          File.expand_path('../../../bin/', __FILE__)
-        end
-      end
-    end
-
     def find_command name
-      File.join bin_path, "bt-#{name}"
+      "bt-#{name}"
     end
   end
 end

--- a/lib/bt/git.rb
+++ b/lib/bt/git.rb
@@ -19,7 +19,7 @@ module BT
 
     def stages
       (commit.tree / 'stages').blobs.map do |stage_blob|
-        Stage.new pipeline, self, stage_blob.basename, YAML::load(stage_blob.data)
+        Stage.new self, stage_blob.basename, YAML::load(stage_blob.data)
       end
     end
 

--- a/lib/bt/git.rb
+++ b/lib/bt/git.rb
@@ -17,6 +17,12 @@ module BT
       repository.result(self, name)
     end
 
+    def stages
+      (commit.tree / 'stages').blobs.map do |stage_blob|
+        Stage.new pipeline, self, stage_blob.basename, YAML::load(stage_blob.data)
+      end
+    end
+
     def workspace depends, &block
       repository.working_tree do |t|
         depends.each { |n| t.checkout_result n}
@@ -127,7 +133,7 @@ module BT
         git.commit({
           :raise => true,
           :author => 'Build Thing <build@thing.invalid>',
-          :'allow-empty' => true, 
+          :'allow-empty' => true,
           :cleanup => 'verbatim',
           :message => "#{message.strip}"
         })

--- a/lib/bt/pipeline.rb
+++ b/lib/bt/pipeline.rb
@@ -2,17 +2,17 @@ module BT
   require 'yaml'
 
   class Stage < Struct.new(:pipeline, :commit, :name, :specification, :needs, :run, :results)
+    def initialize(pipeline, commit, name, specification)
+      super(pipeline, commit, name, specification, [], nil, [])
+      merge! specification
+    end
+
     def ok?
       (r = result) && r.message.start_with?('PASS')
     end
 
     def done?
       result
-    end
-
-    def initialize(pipeline, commit, name, specification)
-      super(pipeline, commit, name, specification, [], nil, [])
-      merge! specification
     end
 
     def needs
@@ -24,7 +24,7 @@ module BT
     end
 
     def result
-      pipeline.result self
+      commit.result name
     end
 
     def ready?

--- a/lib/bt/pipeline.rb
+++ b/lib/bt/pipeline.rb
@@ -1,12 +1,12 @@
 module BT
   require 'yaml'
 
-  class Stage < Struct.new(:pipeline, :commit, :name, :specification, :needs, :run, :results)
+  class Stage < Struct.new(:commit, :name, :specification, :needs, :run, :results)
 
     MSG = 'bt loves you'
 
-    def initialize(pipeline, commit, name, specification)
-      super(pipeline, commit, name, specification, [], nil, [])
+    def initialize(commit, name, specification)
+      super(commit, name, specification, [], nil, [])
       merge! specification
     end
 

--- a/lib/bt/pipeline.rb
+++ b/lib/bt/pipeline.rb
@@ -1,7 +1,7 @@
 module BT
   require 'yaml'
 
-  class Stage < Struct.new(:pipeline, :name, :specification, :needs, :run, :results)
+  class Stage < Struct.new(:pipeline, :commit, :name, :specification, :needs, :run, :results)
     def ok?
       (r = result) && r.message.start_with?('PASS')
     end
@@ -10,8 +10,8 @@ module BT
       result
     end
 
-    def initialize(pipeline, name, specification)
-      super(pipeline, name, specification, [], nil, [])
+    def initialize(pipeline, commit, name, specification)
+      super(pipeline, commit, name, specification, [], nil, [])
       merge! specification
     end
 
@@ -67,7 +67,7 @@ module BT
 
     def stages
       (commit.tree / 'stages').blobs.map do |stage_blob|
-        Stage.new self, stage_blob.basename, YAML::load(stage_blob.data)
+        Stage.new self, commit, stage_blob.basename, YAML::load(stage_blob.data)
       end
     end
 

--- a/lib/bt/pipeline.rb
+++ b/lib/bt/pipeline.rb
@@ -66,10 +66,6 @@ module BT
   end
 
   class Pipeline < Struct.new :commit
-    def result stage
-      commit.result stage.name
-    end
-
     def ready
       incomplete.select { |stage| stage.ready? }
     end
@@ -80,12 +76,8 @@ module BT
       end
     end
 
-    def done
-      stages.select { |s| s.done? }
-    end
-
     def incomplete
-      stages - done
+      stages.select { |s| !s.done? }
     end
   end
 end

--- a/lib/bt/pipeline.rb
+++ b/lib/bt/pipeline.rb
@@ -39,7 +39,7 @@ module BT
     end
 
     def ready?
-      needs.all?(&:done?)
+      needs.all?(&:done?) && !done?
     end
 
     def run
@@ -67,15 +67,7 @@ module BT
 
   class Pipeline < Struct.new :commit
     def ready
-      incomplete.select { |stage| stage.ready? }
-    end
-
-    def stages
-      commit.stages
-    end
-
-    def incomplete
-      stages.select { |s| !s.done? }
+      commit.stages.select(&:ready?)
     end
   end
 end

--- a/lib/bt/pipeline.rb
+++ b/lib/bt/pipeline.rb
@@ -18,6 +18,7 @@ module BT
       result
     end
 
+    #TODO: Remove dependency on pipeline
     def needs
       pipeline.stages.select { |s| self[:needs].include? s.name }
     end

--- a/lib/bt/pipeline.rb
+++ b/lib/bt/pipeline.rb
@@ -18,9 +18,8 @@ module BT
       result
     end
 
-    #TODO: Remove dependency on pipeline
     def needs
-      pipeline.stages.select { |s| self[:needs].include? s.name }
+      commit.stages.select { |s| self[:needs].include? s.name }
     end
 
     def build
@@ -72,9 +71,7 @@ module BT
     end
 
     def stages
-      (commit.tree / 'stages').blobs.map do |stage_blob|
-        Stage.new self, commit, stage_blob.basename, YAML::load(stage_blob.data)
-      end
+      commit.stages
     end
 
     def incomplete

--- a/lib/bt/pipeline.rb
+++ b/lib/bt/pipeline.rb
@@ -28,7 +28,7 @@ module BT
     end
 
     def ready?
-      (needs - pipeline.done).empty?
+      needs.all?(&:done?)
     end
 
     def run

--- a/lib/bt/stage.rb
+++ b/lib/bt/stage.rb
@@ -64,10 +64,4 @@ module BT
       hash.each_pair { |k, v| self[k] = v }
     end
   end
-
-  class Pipeline < Struct.new :commit
-    def ready
-      commit.stages.select(&:ready?)
-    end
-  end
 end

--- a/spec/bt_spec.rb
+++ b/spec/bt_spec.rb
@@ -207,18 +207,18 @@ class Project
   end
 
   def build
-    output = %x{./bin/bt-go --once --debug --directory #{repo.working_dir} 2>&1}
+    output = %x{./env bt-go --once --debug --directory #{repo.working_dir} 2>&1}
     raise output unless $?.exitstatus.zero?
   end
 
   def results
-    output = %x{./bin/bt-results --debug --uri #{repo.working_dir} 2>&1}
+    output = %x{./env bt-results --debug --uri #{repo.working_dir} 2>&1}
     raise output unless $?.exitstatus.zero?
     output
   end
 
   def ready?
-    output = %x{./bin/bt-ready #{repo.working_dir}}
+    output = %x{./env bt-ready #{repo.working_dir}}
     raise output unless $?.exitstatus.zero?
     !output.empty?
   end


### PR DESCRIPTION
This reduces the complexity of resolving executables, this should really be a responsibility of packaging tools. 
