### PR TITLE
Fixed #15.

### DIFF
--- a/lib/bt/git.rb
+++ b/lib/bt/git.rb
@@ -43,7 +43,7 @@ module BT
     # TODO: Mirror is not the right word.
     def self.mirror uri, &block
       Dir.mktmpdir(['bt', '.git']) do |tmp_dir|
-        repo = Grit::Repo.new(tmp_dir).fork_bare_from uri, :timeout => false
+        repo = Grit::Repo.new(tmp_dir).fork_bare_from uri, :timeout => false, :mirror => true
         Mirror.new repo.path, &block
       end
     end


### PR DESCRIPTION
Added mirror switch to fork_bare_from call in Repository#mirror so that
remote origin is available (older git versions do not automatically add
the remote on a bare clone).
