### PR TITLE
Edited README.md via GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ What `git` is to version control, `bt` is to continuous integration.
 ## Requirements
 
 * Ruby 1.9
+* LibYAML
 
 ## HUH?
 


### PR DESCRIPTION
psych depends on libyaml. I had to install it with my package manager of choice (it can also be installed via rvm package), then rebuild ruby with "--with-libyaml". Is there a way we can make this more obvious for the uninitiated? 
