### PR TITLE
Most command usage instructions are missing hyphens between bt and the command name

### DIFF
--- a/bin/bt-agent
+++ b/bin/bt-agent
@@ -96,7 +96,7 @@ Local network build leadership (plumbing)
 You probably don't want to be running this directly.
 
 Usage:
-\tbt agent <build>
+\tbt-agent <build>
   EOS
 end
 

--- a/bin/bt-go
+++ b/bin/bt-go
@@ -12,7 +12,7 @@ opts = Trollop::options do
 Builds ready stages until there aren't any.
 
 Usage:
-\tbt go
+\tbt-go
   EOS
   opt :debug, 'Debugging text scrolls'
   opt :once, 'Build only the next ready stage'

--- a/bin/bt-results
+++ b/bin/bt-results
@@ -10,7 +10,7 @@ opts = Trollop::options do
 Shows build results for head.
 
 Usage:
-\tbt results [OPTIONS...] [URI|DIRECTORY]
+\tbt-results [OPTIONS...] [URI|DIRECTORY]
   EOS
   opt :debug, 'Debugging text scrolls'
   opt :commit, 'Commit to get results for', :default => 'HEAD'

--- a/bin/bt-watch
+++ b/bin/bt-watch
@@ -11,7 +11,7 @@ opts = Trollop::options do
 Watch a repository for stages to build
 
 Usage:
-\tbt watch [repository]
+\tbt-watch [repository]
   EOS
   opt :debug, "Debugging text scrolls"
 end


### PR DESCRIPTION
So I added them. WOW.
